### PR TITLE
✅Fixed ratelimit bc it is not working as you want it to work

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,8 @@ if (production) {
 	const rateLimit = require("express-rate-limit");
 	const limiter = rateLimit({
 		windowMs: 60 * 1000, // 1 min
-		max: 500, // limit each IP to 500 requests per min
+		max: 52, // limit each IP to 52 requests per min 
+		//Edited from 500 to 52 requests per min. bc 500 is too much and people can abuse API, in clonclusion it is not working as you want it to work. #FixByLuis
 	});
 	app.use(limiter);
 }


### PR DESCRIPTION
By leaving an exaggerated amount as a limit, it will seem that the code does not work correctly because it does not really limit the number of requests per minute that a user (without a script) can make by abusing the API. This amount does not allow DDoS attacks to be detected either. and block the requests (Mostly via socket for online games)