### PR TITLE
Add doctype to shop html

### DIFF
--- a/views/shop.ejs
+++ b/views/shop.ejs
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 
 /* Design */


### PR DESCRIPTION
Without doctype the doument will enter "Quirk Mode", at least on chrome, and quirk mode can result in some unexpected behaviours.