### PR TITLE
Remove the <br /> tags because they were making the settings popup not centred.

### DIFF
--- a/src/settings.html
+++ b/src/settings.html
@@ -3,7 +3,7 @@
     cursor: default;
     padding: 15px;
     background-color: #000000;
-    width: 150%;
+    width: 100%;
     border-radius: 16px;
   }
   #settings-pop-up h1 {
@@ -29,14 +29,14 @@
   <h1>Settings</h1>
   <br />
   <label for="movement">Movement mode:</label>
-  <br /><br />
+  <!-- <br /><br /> -->
   <select name="movement" id="movement">
     <option value="mouse">Mouse Only</option>
     <option value="keys">Mouse + Keys</option>
   </select>
   <br /><br />
   <label for="sound">Sound:</label>
-  <br /><br />
+  <!-- <br /><br /> -->
   <select name="sound" id="sound">
     <option value="high">High Volume</option>
     <option value="normal">Normal</option>
@@ -45,7 +45,7 @@
   </select>
   <br /><br />
   <label for="sound">Server:</label>
-  <br /><br />
+  <!-- <br /><br /> -->
   <select name="server" id="server">
     <option value="auto" id="auto">Auto</option>
     <option value="us1" id="us1">USA</option>


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/97064249/181393335-5d83a635-2cae-42e3-93d6-0c08db1d050d.png)


After:
![after](https://user-images.githubusercontent.com/97064249/181393222-8ab9306f-80fb-4e2a-86fe-20cfb38cc06e.png)

