### PR TITLE
Evolution Ability Patch

### DIFF
--- a/classes/Player.js
+++ b/classes/Player.js
@@ -287,7 +287,7 @@ var move = true;
       && evolutions[this.evolution].subEvolutions
       && evolutions[this.evolution].subEvolutions.length > 2
       && evolutions[this.evolution].subEvolutions[0] <= this.coins
-      && this.evolutionQueue.findIndex((q) => q[0] == evolutions[this.evolution].subEvolutions[1] && q[1] == evolutions[this.evolution].subEvolutions[2]) == -1
+      && this.evolutionQueue.findIndex((q) => q[0] == evolutions[this.evolution].subEvolutions[1].name && q[1] == evolutions[this.evolution].subEvolutions[2].name) == -1
       ) this.evolutionQueue.push(evolutions[this.evolution].subEvolutions.slice(1).map((e)=>e.name));
 
   }

--- a/classes/Player.js
+++ b/classes/Player.js
@@ -46,6 +46,8 @@ class Player {
     this.ability = 0;
     this.abilityActive = false;
 
+    this.prevAbilityCooldown = null;
+
    this.skin = "player";
     this.levelScale = 0.85;
 
@@ -351,11 +353,15 @@ return false;
     this.healWait = 5000;
     this.leech =1;
 
+    if (this.ability <= Date.now()) {
+      this.prevAbilityCooldown = null;
+    }
+
     if(Object.keys(this.evolutionData).length > 0) {
       Object.keys(this.evolutionData.default).forEach((prop) => {
        if(this.hasOwnProperty(prop)) this[prop] *= this.evolutionData.default[prop];
       });
-      if(this.ability > Date.now() +evolutions[this.evolution].abilityCooldown) {
+      if(this.ability > Date.now() + (this.prevAbilityCooldown ?? evolutions[this.evolution].abilityCooldown)) {
       //  console.log("ability",this.ability);
         Object.keys(this.evolutionData.ability).forEach((prop) => {
          if(this.hasOwnProperty(prop)) this[prop] *= this.evolutionData.ability[prop];

--- a/index.js
+++ b/index.js
@@ -1138,7 +1138,9 @@ io.on("connection", async (socket) => {
       var evo = evolutions[eclass];
       console.log(player.name + " evolved to " + eclass);
 
-
+      if (player.evolution) {
+        player.prevAbilityCooldown = evolutions[player.evolution].abilityCooldown;
+      }
 
         player.evolutionData = {default: evo.default(), ability: evo.ability()};
       player.evolution =evo.name;


### PR DESCRIPTION
This patch fixes a bug that when evolving, the player activates the ability for more time than normal. It also patches a bug in the `checkSubEvolutions` function so it actually works now. HOWEVER, [this](https://github.com/codergautam/swordbattle.io/commit/7e5d37eff2626798b0f5bbcf871beda821e3244e) commit will break the solution I made. It essentially resets the timer so that whenever you evolve, you can immediately use the ability. My patch will keep the cooldown of the last use of the ability until it is over so that you don't get people spamming all the abilities on each next level. For this to work, that commit would need to be undone. I also noticed that for some reason, when you evolve, the client sends multiple requests to the server to evolve, which was breaking the code because `checkSubEvolutions` wasn't working. Now that `checkSubEvolutions` works, it's not a problem, but I'm not quite sure why you need to send multiple requests.